### PR TITLE
PR: Pin minimum Python version to 3.6

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                PYTHON_VERSION: ["3.5", "3.6", "3.7", "3.8"]
+                PYTHON_VERSION: ["3.6", "3.7", "3.8"]
         steps:
             - name: Checkout branch/PR
               uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     long_description=get_description(),
     long_description_content_type='text/markdown',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    python_requires='>= 3.6',
     install_requires=REQUIREMENTS,
     include_package_data=True,
     entry_points={"pyls": ["pyls_spyder = pyls_spyder.plugin"]},


### PR DESCRIPTION
This PR pins the minimum required Python version to 3.6, thus deprecating 2.7 and < 3.6 Python versions. 