### PR TITLE
PR: Use python-lsp-server instead of python-language-server

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -30,7 +30,7 @@ jobs:
                 python-version: ${{ matrix.PYTHON_VERSION }}
             - name: Install build/test dependencies
               shell: bash -l {0}
-              run: pip install python-language-server[all] pytest pytest-cov coverage mock
+              run: pip install python-lsp-server[all] pytest pytest-cov coverage mock
             - name: Run tests
               shell: bash -l {0}
               run: pytest -v -x --cov=pyls_spyder pyls_spyder/tests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 
 ## Overview
-Spyder extensions for the [python-language-server](https://github.com/palantir/python-language-server) (pyls). This package provides Spyder-specific extras for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/specifications/specification-current/) (LSP) on Python, such as document symbol searching and others.
+Spyder extensions for the [python-lsp-server](https://github.com/python-lsp/python-lsp-server) (pylsp). This package provides Spyder-specific extras for the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/specifications/specification-current/) (LSP) on Python, such as document symbol searching and others.
 
 
 ## Installing
@@ -27,18 +27,18 @@ pip install pyls-spyder
 ```
 
 ## Dependencies
-This package depends on the [python-language-server](https://github.com/palantir/python-language-server) to integrate the Spyder-specific extensions.
+This package depends on the [python-lsp-server](https://github.com/python-lsp/python-lsp-server) to integrate the Spyder-specific extensions.
 
 
 ## Installing locally
-To install and develop spyder-pyls locally, you will need to install the python-language-server:
+To install and develop spyder-pyls locally, you will need to install the python-lsp-server:
 
 ```bash
 # Using conda
-conda install python-language-server
+conda install python-lsp-server
 
 # Using pip
-pip install python-language-server
+pip install python-lsp-server
 ```
 
 Then, you can install the package locally using pip:
@@ -89,7 +89,7 @@ This plugin can be configured by using the key `pyls_spyder` when calling `works
 </table>
 
 ## Changelog
-Please see our [CHANGELOG](https://github.com/spyder-ide/three-merge/blob/master/CHANGELOG.md) file to learn more about our new features and improvements.
+Please see our [CHANGELOG](https://github.com/spyder-ide/pyls-spyder/blob/master/CHANGELOG.md) file to learn more about our new features and improvements.
 
 
 ## Contribution guidelines

--- a/pyls_spyder/plugin.py
+++ b/pyls_spyder/plugin.py
@@ -18,7 +18,7 @@ from pylsp.config.config import Config
 from pylsp.workspace import Workspace, Document
 
 # Local imports
-from pylsp_spyder.utils import RegexEvaluator
+from pyls_spyder.utils import RegexEvaluator
 
 # Code cell regular expressions
 # 1. Cells declared with percentages, i.e., # %% Cell

--- a/pyls_spyder/plugin.py
+++ b/pyls_spyder/plugin.py
@@ -13,12 +13,12 @@ import re
 from typing import List, Dict, Tuple
 
 # PyLS imports
-from pyls import hookimpl
-from pyls.config.config import Config
-from pyls.workspace import Workspace, Document
+from pylsp import hookimpl
+from pylsp.config.config import Config
+from pylsp.workspace import Workspace, Document
 
 # Local imports
-from pyls_spyder.utils import RegexEvaluator
+from pylsp_spyder.utils import RegexEvaluator
 
 # Code cell regular expressions
 # 1. Cells declared with percentages, i.e., # %% Cell
@@ -87,7 +87,7 @@ def create_fold_region(start_line: int, end_line: int):
 
 
 @hookimpl
-def pyls_document_symbols(config: Config,
+def pylsp_document_symbols(config: Config,
                           workspace: Workspace,
                           document: Document) -> List[Dict]:
     """Cell and block comment extraction."""
@@ -155,7 +155,7 @@ def pyls_document_symbols(config: Config,
 
 
 @hookimpl
-def pyls_folding_range(
+def pylsp_folding_range(
         config: Config,
         workspace: Workspace,
         document: Document) -> List[Dict]:

--- a/pyls_spyder/tests/test_plugin.py
+++ b/pyls_spyder/tests/test_plugin.py
@@ -9,15 +9,15 @@
 """pyls-spyder plugin tests."""
 
 # PyLS imports
-from pyls import uris
-from pyls.workspace import Document
+from pylsp import uris
+from pylsp.workspace import Document
 
 # pytest imports
 import pytest
 from unittest.mock import MagicMock
 
 # Local imports
-from pyls_spyder.plugin import pyls_document_symbols, pyls_folding_range
+from pyls_spyder.plugin import pylsp_document_symbols, pylsp_folding_range
 
 
 DOC_URI = uris.from_fs_path(__file__)
@@ -64,7 +64,7 @@ def config():
 
 def test_cell_block_symbols(config, workspace):
     document = Document(DOC_URI, workspace, DOC)
-    symbols = pyls_document_symbols(config, workspace, document)
+    symbols = pylsp_document_symbols(config, workspace, document)
     expected = [
         ('Unnamed cell 1', 1, 22, 225),
         ('Imports', 2, 2, 224),
@@ -96,7 +96,7 @@ def test_cell_block_symbols(config, workspace):
 def test_ungroup_cell_symbols(config, workspace):
     document = Document(DOC_URI, workspace, DOC)
     config.plugin_settings = lambda _: {'group_cells': False}
-    symbols = pyls_document_symbols(config, workspace, document)
+    symbols = pylsp_document_symbols(config, workspace, document)
     expected = [
         ('Unnamed cell 1', 1, 1, 225),
         ('Imports', 2, 2, 224),
@@ -128,7 +128,7 @@ def test_ungroup_cell_symbols(config, workspace):
 def test_disable_block_comments(config, workspace):
     document = Document(DOC_URI, workspace, DOC)
     config.plugin_settings = lambda _: {'enable_block_comments': False}
-    symbols = pyls_document_symbols(config, workspace, document)
+    symbols = pylsp_document_symbols(config, workspace, document)
     expected = [
         ('Unnamed cell 1', 1, 22, 225),
         ('Other cell', 6, 6, 225),
@@ -153,7 +153,7 @@ def test_disable_block_comments(config, workspace):
 
 def test_cell_folding_regions(config, workspace):
     document = Document(DOC_URI, workspace, DOC)
-    regions = pyls_folding_range(config, workspace, document)
+    regions = pylsp_folding_range(config, workspace, document)
     expected = [
         (1, 22),
         (6, 9),

--- a/setup.py
+++ b/setup.py
@@ -38,24 +38,24 @@ def get_description():
     return data
 
 
-REQUIREMENTS = ['python-language-server >= 0.36.2']
+REQUIREMENTS = ['python-lsp-server >= 1.0.1']
 
 setup(
     name='pyls-spyder',
     version=get_version(),
-    keywords=['PyLS', 'Plugin'],
+    keywords=['PyLSP', 'Plugin'],
     url='https://github.com/spyder-ide/pyls-spyder',
     license='MIT',
     author='Spyder Project Contributors',
     author_email='spyder.python@gmail.com',
-    description='Spyder extensions for the python-language-server',
+    description='Spyder extensions for the python-lsp-server',
     long_description=get_description(),
     long_description_content_type='text/markdown',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     python_requires='>= 3.6',
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    entry_points={"pyls": ["pyls_spyder = pyls_spyder.plugin"]},
+    entry_points={"pylsp": ["pyls_spyder = pyls_spyder.plugin"]},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Fixes #24 

This PR migrates pyls-spyder to use the community-maintained python-lsp-server instead of Palantir's python-language-server.